### PR TITLE
Passing error from driver on new conn failure

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -183,6 +183,7 @@ Pool.prototype.reserve = function(callback) {
     } catch (err) {
       winston.error(err);
       conn = null;
+      return callback(err);
     }
   }
 


### PR DESCRIPTION
Without this there are no details of the error available to the application when a new JDBC Connection cannot be created